### PR TITLE
Auto requires

### DIFF
--- a/src/aim/gccbuildrules.py
+++ b/src/aim/gccbuildrules.py
@@ -20,7 +20,7 @@ def add_ar(nfw: Writer):
 
 def add_exe(nfw: Writer):
     # TODO: origin should only really be added when we need to link against an so.
-    command = f"$compiler $defines $flags $includes $in -o $exe_name -Wl,-rpath='$$ORIGIN' $linker_args"
+    command = f"$compiler $defines $flags $includes $in -o $exe_name -Wl,-rpath='$$ORIGIN:$$ORIGIN/../lib_calculator_so' $linker_args"
     nfw.rule(name="exe",
              description="Builds an executable.",
              command=command)

--- a/src/aim/gccbuildrules.py
+++ b/src/aim/gccbuildrules.py
@@ -20,7 +20,7 @@ def add_ar(nfw: Writer):
 
 def add_exe(nfw: Writer):
     # TODO: origin should only really be added when we need to link against an so.
-    command = f"$compiler $defines $flags $includes $in -o $exe_name -Wl,-rpath='$$ORIGIN:$$ORIGIN/../lib_calculator_so' $linker_args"
+    command = f"$compiler $defines $flags $includes $in -o $exe_name $linker_args"
     nfw.rule(name="exe",
              description="Builds an executable.",
              command=command)

--- a/src/aim/main.py
+++ b/src/aim/main.py
@@ -137,29 +137,29 @@ flags = [
 
 defines = []
 
-[[builds]]
-    name = "lib_calculator"
-    buildRule = "staticlib"
-    outputName = "libCalculator.a"
-    srcDirs = ["../../lib"]
-    includePaths = ["../../include"]
+[[builds]]                              # a list of builds.
+    name = "lib_calculator"             # the unique name for this build.
+    buildRule = "staticlib"             # the type of build, in this case create a static library.
+    outputName = "libCalculator.a"      # the library output name,
+    srcDirs = ["../../lib"]             # the src directories  to build the static library from.
+    includePaths = ["../../include"]   # additional include paths to use during the build.
 
 #[[builds]]
-#    name = "lib_calculator_so"
-#    buildRule = "dynamiclib"
-#    outputName = "libCalculator.so"
-#    srcDirs = ["../../lib"]
-#    includePaths = ["../../include"]
+#    name = "lib_calculator_so"         # the unique name for this build.
+#    buildRule = "dynamiclib"           # the type of build, in this case create a shared library.
+#    outputName = "libCalculator.so"    # the library output name,
+#    srcDirs = ["../../lib"]            # the src directories to build the shared library from.
+#    includePaths = ["../../include"]  # additional include paths to use during the build.
 
 [[builds]]
-    name = "exe"
-    buildRule = "exe"
-    requires = ["lib_calculator"]
-    outputName = "the_calculator.exe"
-    srcDirs = ["../../src"]
-    includePaths = ["../../include"]
-    libraryPaths = ["./lib_calculator"]
-    libraries = ["libCalculator.a"]
+    name = "exe"                        # the unique name for this build.
+    buildRule = "exe"                   # the type of build, in this case an executable.
+    requires = ["lib_calculator"]       # build dependencies. Aim figures out the linker flags for you.
+    outputName = "the_calculator.exe"   # the exe output name,
+    srcDirs = ["../../src"]             # the src directories to build the shared library from.
+    includePaths = ["../../include"]   # additional include paths to use during the build.
+    #libraryPaths = []                   # additional library paths, used for including third party libraries.
+    #libraries = []                      # additional libraries, used for including third party libraries.
 """
 
 CALCULATOR_CPP = """\
@@ -217,22 +217,22 @@ def run_init():
     for target in windows_targets:
         target_dir = build_dir / target
         target_dir.mkdir(exist_ok=True)
-        print(f"\t{str(target_dir)}")
+        # print(f"\t{str(target_dir)}")
 
         toml_file = target_dir / "target.toml"
         toml_file.touch(exist_ok=True)
-        print(f"\t\t{str(toml_file)}")
+        print(f"\t{str(toml_file)}")
 
         toml_file.write_text(WindowsDefaultTomlFile)
 
     for target in linux_targets:
         target_dir = build_dir / target
         target_dir.mkdir(exist_ok=True)
-        print(f"\t{str(target_dir)}")
+        # print(f"\t{str(target_dir)}")
 
         toml_file = target_dir / "target.toml"
         toml_file.touch(exist_ok=True)
-        print(f"\t\t{str(toml_file)}")
+        print(f"\t{str(toml_file)}")
 
         toml_file.write_text(LinuxDefaultTomlFile)
 

--- a/src/aim/main.py
+++ b/src/aim/main.py
@@ -17,7 +17,7 @@ def generate_build_rules(builder, project_dir, parsed_toml):
         build_info["directory"] = project_dir
         build_info["flags"] = flags
         build_info["defines"] = defines
-        builder.build(build_info)
+        builder.build(build_info, parsed_toml)
 
 
 def find_build(build_name, builds):

--- a/src/aim/msvcbuilds.py
+++ b/src/aim/msvcbuilds.py
@@ -49,7 +49,7 @@ def convert_dlls_to_lib(libraries):
 def get_src_files(build):
     directory = build["directory"]
     src_dirs = build["srcDirs"]
-    src_paths = append_paths(directory, src_dirs)
+    src_paths = prepend_paths(directory, src_dirs)
     src_files = flatten(glob("*.cpp", src_paths)) + flatten(glob("*.c", src_paths))
     assert src_files, "Fail to find any source files."
     return src_files
@@ -58,7 +58,7 @@ def get_src_files(build):
 def get_include_paths(build):
     directory = build["directory"]
     include_paths = build.get("includePaths", [])
-    includes = append_paths(directory, include_paths)
+    includes = prepend_paths(directory, include_paths)
     includes = PrefixIncludePath(add_quotes(includes))
     return includes
 
@@ -66,7 +66,7 @@ def get_include_paths(build):
 def get_library_paths(build):
     directory = build["directory"]
     library_paths = build.get("libraryPaths", [])
-    library_paths = append_paths(directory, library_paths)
+    library_paths = prepend_paths(directory, library_paths)
     library_paths = PrefixLibraryPath(add_quotes(library_paths))
     return library_paths
 
@@ -142,7 +142,7 @@ class MSVCBuilds:
         # in the current (exe's) build location.
         build_path = build["buildPath"]
         obj_files = ToObjectFiles(src_files)
-        obj_files = append_paths(build_path, obj_files)
+        obj_files = prepend_paths(build_path, obj_files)
 
         file_pairs = zip(to_str(src_files), to_str(obj_files))
         for src_file, obj_file in file_pairs:

--- a/src/aim/schema.py
+++ b/src/aim/schema.py
@@ -12,10 +12,24 @@ class UniqueNameChecker:
             self.name_lookup.append(value)
 
 
-unique_name_checker = UniqueNameChecker()
+class RequiresExistChecker:
+    def __init__(self, document):
+        self.doc = document
+
+    def check(self, field, requires, error):
+        builds = self.doc["builds"]
+        for value in requires:
+            for build in builds:
+                if value == build["name"]:
+                    break
+            else:
+                error(field, f"{value} does not match any build name. Check spelling.")
 
 
 def target_schema(document):
+    unique_name_checker = UniqueNameChecker()
+    requires_exist_checker = RequiresExistChecker(document)
+
     schema = {
         "cxx": {"required": True, "type": "string"},
         "cc": {"required": True, "type": "string"},
@@ -53,6 +67,7 @@ def target_schema(document):
                         "type": "list",
                         "empty": False,
                         "schema": {"type": "string"},
+                        "check_with": requires_exist_checker.check
                     },
 
                     "buildRule": {
@@ -73,12 +88,14 @@ def target_schema(document):
                         "schema": {"type": "string"}
                     },
 
+                    # TODO add checker to check that the paths exists.
                     "includePaths": {
                         "type": "list",
                         "empty": False,
                         "schema": {"type": "string"}
                     },
 
+                    # TODO add checker to check that the paths exists.
                     "libraryPaths": {
                         "type": "list",
                         "empty": False,
@@ -89,15 +106,6 @@ def target_schema(document):
                     },
 
                     "libraries": {
-                        "type": "list",
-                        "empty": False,
-                        "schema": {"type": "string"},
-                        "dependencies": {
-                            "buildRule": ["exe", "dynamiclib"]
-                        }
-                    },
-
-                    "thirdPartyLibraries": {
                         "type": "list",
                         "empty": False,
                         "schema": {"type": "string"},

--- a/src/aim/utils.py
+++ b/src/aim/utils.py
@@ -1,4 +1,5 @@
 import itertools
+import os
 from pathlib import Path
 from typing import *
 
@@ -41,7 +42,7 @@ def suffix(the_suffix, paths) -> StringList:
     return [str(x) + the_suffix for x in paths]
 
 
-def append_paths(base_path: Path, other_paths: Union[PathList, StringList]):
+def prepend_paths(base_path: Path, other_paths: Union[PathList, StringList]):
     return resolve([base_path / the_path for the_path in other_paths])
 
 
@@ -51,3 +52,7 @@ def resolve(paths: PathList):
 
 def escape_path(word):
     return word.replace('$ ', '$$ ').replace(' ', '$ ').replace(':', '$:')
+
+
+def relpath(src_path: Path, dst_path: Path):
+    return Path(os.path.relpath(str(src_path), str(dst_path)))

--- a/test/project/windows-clang++/target.toml
+++ b/test/project/windows-clang++/target.toml
@@ -1,6 +1,6 @@
 cxx = "clang++"
 cc = "clang"
-ar = "llvm-ar"
+ar = "ar"
 compilerFrontend="gcc"
 
 flags = [
@@ -28,7 +28,5 @@ defines = []
     requires = ["shared"]
     buildRule = "exe"
     outputName = "project.exe"
-    srcDirs = ["../app", "../libproject"]
+    srcDirs = ["../app"]
     includePaths = ["../libproject"]
-    libraryPaths = ["./exe"]
-    libraries = ["libProject.so"]


### PR DESCRIPTION
This pull request adds two new bits of functionality to Aim:
* `libraryPaths` and `libraries` flags are automatically resolved for build dependencies i.e. `requires`.
* `rpath` is automatically update to include any dynamic libraries that are used to build an executable.