### PR TITLE
Make paths relative to project root.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Aim has create some common build targets: `Windows` and `Linux` operating system
 Let's take a look at the `linux-clang++-debug/target.toml` file:
 
 ```toml
+projectRoot = "../.."                   # the relative path from the target build directory to the project src directory.
 cxx = "clang++"                         # the cxx compiler to use.
 cc = "clang"                            # the cc compiler to use.
 ar = "llvm-ar"                          # the archiver to use.

--- a/src/aim/main.py
+++ b/src/aim/main.py
@@ -127,6 +127,8 @@ defines = []
 """
 
 LinuxDefaultTomlFile = """\
+projectRoot = "../.."
+
 cxx = "clang++"
 cc = "clang"
 ar = "ar"
@@ -143,23 +145,23 @@ defines = []
     name = "lib_calculator"             # the unique name for this build.
     buildRule = "staticlib"             # the type of build, in this case create a static library.
     outputName = "libCalculator.a"      # the library output name,
-    srcDirs = ["../../lib"]             # the src directories  to build the static library from.
-    includePaths = ["../../include"]   # additional include paths to use during the build.
+    srcDirs = ["lib"]                   # the src directories  to build the static library from.
+    includePaths = ["include"]    # additional include paths to use during the build.
 
 #[[builds]]
 #    name = "lib_calculator_so"         # the unique name for this build.
 #    buildRule = "dynamiclib"           # the type of build, in this case create a shared library.
 #    outputName = "libCalculator.so"    # the library output name,
-#    srcDirs = ["../../lib"]            # the src directories to build the shared library from.
-#    includePaths = ["../../include"]  # additional include paths to use during the build.
+#    srcDirs = ["lib"]                  # the src directories to build the shared library from.
+#    includePaths = ["include"]         # additional include paths to use during the build.
 
 [[builds]]
     name = "exe"                        # the unique name for this build.
     buildRule = "exe"                   # the type of build, in this case an executable.
     requires = ["lib_calculator"]       # build dependencies. Aim figures out the linker flags for you.
     outputName = "the_calculator.exe"   # the exe output name,
-    srcDirs = ["../../src"]             # the src directories to build the shared library from.
-    includePaths = ["../../include"]   # additional include paths to use during the build.
+    srcDirs = ["src"]                   # the src directories to build the shared library from.
+    includePaths = ["include"]          # additional include paths to use during the build.
     #libraryPaths = []                   # additional library paths, used for including third party libraries.
     #libraries = []                      # additional libraries, used for including third party libraries.
 """
@@ -266,9 +268,16 @@ def run_build(build_name, target_path):
         # with ninja_path.open("w+") as ninja_file:
         #     ninja_writer = Writer(ninja_file)
 
-        target_schema(parsed_toml)
-        parse_toml_file(parsed_toml,
-                        project_dir)
+        root_dir = parsed_toml["projectRoot"]
+        project_dir = (project_dir / root_dir).resolve()
+        assert project_dir.exists(), f"{str(project_dir)} does not exist."
+
+        try:
+            target_schema(parsed_toml, project_dir)
+        except RuntimeError as e:
+            print(f"Error: {e.args[0]}")
+            exit(-1)
+        parse_toml_file(parsed_toml, project_dir)
 
         run_ninja(project_dir, the_build["name"])
 

--- a/src/aim/run.py
+++ b/src/aim/run.py
@@ -1,1 +1,0 @@
-print(__package__)

--- a/test/project/windows-clang++/target.toml
+++ b/test/project/windows-clang++/target.toml
@@ -9,24 +9,26 @@ flags = [
 
 defines = []
 
+projectRoot = ".."
+
 [[builds]]
     name = "static"
     buildRule = "staticlib"
     outputName = "project.lib"
-    srcDirs = ["../libproject"]
-    includePaths = ["../libproject"]
+    srcDirs = ["libproject"]
+    includePaths = ["libproject"]
 
 [[builds]]
     name = "shared"
     buildRule = "dynamiclib"
     outputName = "libProject.so"
-    srcDirs = ["../libproject"]
-    includePaths = ["../libproject"]
+    srcDirs = ["libproject"]
+    includePaths = ["libproject"]
 
 [[builds]]
     name = "exe"
     requires = ["shared"]
     buildRule = "exe"
     outputName = "project.exe"
-    srcDirs = ["../app"]
-    includePaths = ["../libproject"]
+    srcDirs = ["app"]
+    includePaths = ["libproject"]


### PR DESCRIPTION
Closes #6 
This commit adds `projectRoot` field to the target schema.
This allows a developer to spectify where the project is in relation to
the target build.
This allows directories to be specified as if running from the project
root rather than from the build dir. For example it allows a src dir to
be specified as `srcDirs = ["src"]` rather than `srcDirs =
["../../srcDirs"]`.