### PR TITLE
Check library names

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 </p>
 
 ![GitHub release (latest SemVer including pre-releases)](https://img.shields.io/github/v/release/diwalkerdev/aim?include_prereleases)
+![GitHub commits since latest release (by SemVer including pre-releases)](https://img.shields.io/github/commits-since/diwalkerdev/aim/latest/dev?include_prereleases)
 ![Python package](https://github.com/diwalkerdev/Aim/workflows/Python%20package/badge.svg?branch=dev)
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/aim-build)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Project goals:
 
 \* A **build target** is some combination of _things_ that affects the output binary. See Methodology for more information.
 
+See [ShapeAttack](https://github.com/diwalkerdev/ShapeAttack), for a demo of how Aim can be used in a real world example.
+
 
 ## Known Limitations
 * Windows support is still in development.

--- a/src/aim_build/main.py
+++ b/src/aim_build/main.py
@@ -68,7 +68,7 @@ def entry():
         "list", help="Displays the builds for the target"
     )
     build_parser.add_argument(
-        "--target", type=str, help="Path to target file directory"
+        "--target", type=str, required=True, help="Path to target file directory"
     )
 
     init_parser = sub_parser.add_parser("init", help="Creates a project structure.")
@@ -80,7 +80,7 @@ def entry():
     build_parser.add_argument("build", type=str, help="The build name")
 
     build_parser.add_argument(
-        "--target", type=str, help="Path to target file directory"
+        "--target", type=str, required=True, help="Path to target file directory"
     )
 
     build_parser.add_argument(


### PR DESCRIPTION
Fixes a number of issues but most importantly now checks the naming of convention of library names provide to the `library` field of `target.toml`.