### PR TITLE
Compile commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,6 @@ dmypy.json
 .ninja_log
 *.ninja
 *.dylib
+
+
+compile_commands.json

--- a/src/aim_build/main.py
+++ b/src/aim_build/main.py
@@ -313,6 +313,9 @@ def run_build(build_name, target_path, skip_ninja_regen):
         if not skip_ninja_regen:
             print("Generating ninja files...")
             run_ninja_generation(parsed_toml, project_dir, build_dir)
+            with (build_dir.resolve() / "compile_commands.json").open("w+") as cc:
+                command = ["ninja", "-C", str(build_dir.resolve()), "-t", "compdb"]
+                subprocess.run(command, stdout=cc)
 
         run_ninja(build_dir, the_build["name"])
 


### PR DESCRIPTION
closes #38 

Adds top level build.ninja file which builds the entire project. This is useful for generating the compilation database (https://sarcasm.github.io/notes/dev/compilation-database.html#how-to-generate-a-json-compilation-database) which aim now generates automatically as a result of the pr.